### PR TITLE
Atualiza documentação de testes unitários do catálogo e reforça validação de paginação na API

### DIFF
--- a/docs/08-Registro de Testes Unitários.md
+++ b/docs/08-Registro de Testes Unitários.md
@@ -15,46 +15,77 @@ Testes unitários ajudam a:
 
 ## Configuração do Ambiente
 
-Para começar a escrever testes unitários em um projeto backend utilizando C#, siga os passos abaixo:
+Este projeto utiliza Node.js, pnpm e Vitest para testes unitários no backend.
 
-1. **Instale o .NET SDK**: Certifique-se de ter o [.NET SDK](https://dotnet.microsoft.com/download) instalado.
+1. **Instalar dependências do workspace**
 
-2. **Crie um projeto de testes**: No terminal, navegue até o diretório do seu projeto e execute o seguinte comando para criar um projeto de testes usando xUnit (um framework popular de testes unitários para .NET):
+   ```bash
+   pnpm install
+   ```
 
-    ```bash
-    dotnet new xunit -o tests
-    ```
+2. **Acessar a aplicação de API**
 
-3. **Adicione uma referência ao seu projeto principal**: No diretório do projeto de testes, adicione uma referência ao seu projeto principal:
+   ```bash
+   cd src/apps/api
+   ```
 
-    ```bash
-    dotnet add reference ../src/MyProject.csproj
-    ```
+3. **Comando de teste da API (referência)**
 
-4. **Organize sua estrutura de diretórios**: Uma estrutura comum de projeto é a seguinte:
+   ```bash
+   pnpm test
+   ```
 
-    ```
-    MyProject/
-    ├── src/
-    │   └── MyProject.cs
-    └── tests/
-        └── MyProject.Tests.cs
-    ```
+4. **Comando para executar somente o arquivo de catálogo (referência)**
 
-## Exemplo de Teste Unitário
+   ```bash
+   pnpm test src/__tests__/catalog.test.ts
+   ```
 
-Aqui está um exemplo simples de um teste unitário em C# usando xUnit. Vamos supor que temos um método na classe `Calculator` que soma dois números.
+## Catalog
 
-```csharp
-// src/MyProject.cs
+### Arquivo de Teste
 
-namespace MyProject
-{
-    public class Calculator
-    {
-        public int Add(int a, int b)
-        {
-            return a + b;
-        }
-    }
-}
+- `src/apps/api/src/__tests__/catalog.test.ts`
+
+### Cobertura Registrada
+
+Os testes de catalog cobrem:
+
+1. **Store do catálogo**
+- Criação de índices esperados (`profileId`, `profileId + type`, `profileId + name`).
+- Garantia de que índices não são recriados desnecessariamente na mesma instância de banco.
+- Validação de retorno da collection e uso correto do `getDb` injetado.
+
+2. **GET /api/catalog**
+- Retorno `401` para requisição sem sessão.
+- Paginação padrão e paginação via query string.
+- Limites máximos de paginação (`page` e `limit`).
+- Filtro por tipo (`product`/`service`).
+- Busca textual em `name` e `description`.
+- Ordenação padrão por data de criação.
+- Isolamento de dados por `profileId` autenticado.
+- Serialização de `_id` e datas para string.
+- Presença condicional de campos opcionais (`description`, `costPrice`).
+
+3. **POST /api/catalog**
+- Retorno `401` sem autenticação.
+- Criação com sucesso (`201`) para payload válido.
+- Inclusão e omissão de campos opcionais.
+- Validação de payload inválido (`type`, `unitPrice`, `unitMeasure`) com retorno `400`.
+
+4. **PUT /api/catalog/:itemId**
+- Retorno `401` sem autenticação.
+- Retorno `404` para item inexistente no escopo do perfil.
+- Atualização parcial de campos.
+- Validação de corpo vazio (`400`).
+- Validação de formato inválido de `itemId` (`400`).
+
+5. **DELETE /api/catalog/:itemId**
+- Retorno `401` sem autenticação.
+- Retorno `404` para item inexistente.
+- Exclusão com sucesso (`204`).
+- Validação de formato inválido de `itemId` (`400`).
+
+## Observações
+
+- Os testes são executados com mocks/stubs de dependências (autenticação, profile store e acesso a banco), garantindo isolamento da unidade testada.

--- a/src/apps/api/src/__tests__/catalog.test.ts
+++ b/src/apps/api/src/__tests__/catalog.test.ts
@@ -1,0 +1,1122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ObjectId, type Db, type WithId } from 'mongodb';
+import type { FastifyInstance } from 'fastify';
+
+import { buildApp } from '../app.js';
+import type { AuthService } from '../lib/auth.js';
+import { createCatalogStore, type CatalogItem, type CatalogStore } from '../lib/catalog.js';
+import type { MongoService } from '../lib/mongo.js';
+import {
+  createProfileStore,
+  type ProfileDocument,
+  type ProfileStore,
+} from '../lib/profile.js';
+
+const DEFAULT_ENV = {
+  BETTER_AUTH_SECRET: '01234567890123456789012345678901',
+  BETTER_AUTH_URL: 'http://localhost:3000',
+  MONGODB_URI: 'mongodb://localhost:27017/meupj',
+};
+
+const createProfileFixture = (authUserId = 'auth-user-1'): WithId<ProfileDocument> => ({
+  _id: new ObjectId(),
+  authUserId,
+  business: {
+    name: null,
+    document: null,
+    phone: null,
+    email: null,
+    logo: null,
+    color: null,
+    footer: null,
+    address: {
+      zipCode: null,
+      street: null,
+      number: null,
+      complement: null,
+      district: null,
+      city: null,
+      state: null,
+      country: null,
+    },
+  },
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+});
+
+const createCatalogItemFixture = (
+  profileId: string,
+  overrides?: Partial<CatalogItem>,
+): WithId<CatalogItem> => ({
+  _id: new ObjectId(),
+  profileId,
+  type: 'product',
+  name: 'Sample Product',
+  unitPrice: 99.99,
+  unitMeasure: 'unit',
+  createdAt: new Date('2026-01-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+  ...overrides,
+});
+
+const createAuthServiceMock = (overrides: Partial<AuthService> = {}): AuthService => ({
+  handleRequest:
+    overrides.handleRequest ??
+    (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }),
+      )),
+  getSessionFromHeaders: overrides.getSessionFromHeaders ?? (() => Promise.resolve(null)),
+});
+
+const createMongoMock = (healthy: boolean): MongoService => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  isHealthy: vi.fn(() => healthy),
+  getStatus: vi.fn(() => ({
+    state: healthy ? ('connected' as const) : ('degraded' as const),
+    lastError: healthy ? null : 'connection refused',
+  })),
+  getClient: vi.fn(() => {
+    throw new Error('not implemented in tests');
+  }),
+  getDb: vi.fn(() => {
+    throw new Error('not implemented in tests');
+  }),
+  close: vi.fn().mockResolvedValue(undefined),
+});
+
+const createProfileStoreMock = (profile = createProfileFixture()): ProfileStore => ({
+  ensureIndexes: () => Promise.resolve(undefined),
+  getByAuthUserId: () => Promise.resolve(profile),
+  ensureByAuthUserId: () => Promise.resolve(profile),
+});
+
+type FakeCollection = {
+  createIndex: ReturnType<typeof vi.fn>;
+  insertOne: ReturnType<typeof vi.fn>;
+  findOne: ReturnType<typeof vi.fn>;
+  updateOne: ReturnType<typeof vi.fn>;
+  deleteOne: ReturnType<typeof vi.fn>;
+  find: ReturnType<typeof vi.fn>;
+  countDocuments: ReturnType<typeof vi.fn>;
+  db: { collection: ReturnType<typeof vi.fn> };
+};
+
+const createFakeCatalogDb = (): {
+  db: Db;
+  records: Map<string, WithId<CatalogItem>>;
+  getCreateIndexCalls: () => number;
+} => {
+  const records = new Map<string, WithId<CatalogItem>>();
+  let createIndexCalls = 0;
+
+  const catalogCollection: FakeCollection = {
+    createIndex: vi.fn(() => {
+      createIndexCalls += 1;
+      return Promise.resolve('index_created');
+    }),
+    insertOne: vi.fn((doc: Omit<CatalogItem, '_id'>) => {
+      const id = new ObjectId();
+      const fullDoc: WithId<CatalogItem> = {
+        _id: id,
+        ...doc,
+      };
+      records.set(id.toHexString(), fullDoc);
+      return Promise.resolve({ insertedId: id, acknowledged: true });
+    }),
+    findOne: vi.fn((filter: Record<string, unknown>) => {
+      if (filter._id instanceof ObjectId) {
+        const item = records.get(filter._id.toHexString());
+        if (filter.profileId && item && item.profileId !== filter.profileId) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(item ?? null);
+      }
+      return Promise.resolve(null);
+    }),
+    updateOne: vi.fn((filter: Record<string, unknown>, update: { $set: Record<string, unknown> }) => {
+      let matched = false;
+      let updated = false;
+
+      if (filter._id instanceof ObjectId) {
+        const item = records.get(filter._id.toHexString());
+        if (item && (!filter.profileId || item.profileId === filter.profileId)) {
+          matched = true;
+          Object.assign(item, update.$set);
+          updated = true;
+        }
+      }
+
+      return Promise.resolve({
+        acknowledged: true,
+        matchedCount: matched ? 1 : 0,
+        modifiedCount: updated ? 1 : 0,
+        upsertedId: null,
+      });
+    }),
+    deleteOne: vi.fn((filter: Record<string, unknown>) => {
+      if (filter._id instanceof ObjectId) {
+        const id = filter._id.toHexString();
+        const item = records.get(id);
+        if (item && (!filter.profileId || item.profileId === filter.profileId)) {
+          records.delete(id);
+          return Promise.resolve({ deletedCount: 1, acknowledged: true });
+        }
+      }
+      return Promise.resolve({ deletedCount: 0, acknowledged: true });
+    }),
+    find: vi.fn((filter: Record<string, unknown>) => {
+      let items = Array.from(records.values());
+
+      if (filter.profileId) {
+        items = items.filter((item) => item.profileId === filter.profileId);
+      }
+
+      if (filter.type) {
+        items = items.filter((item) => item.type === filter.type);
+      }
+
+      if (filter.$or) {
+        const orConditions = filter.$or as Array<Record<string, unknown>>;
+        items = items.filter((item) => {
+          return orConditions.some((condition) => {
+            if (condition.name && typeof condition.name === 'object' && '$regex' in condition.name) {
+              const regex = new RegExp((condition.name as any).$regex, (condition.name as any).$options);
+              return regex.test(item.name);
+            }
+            if (
+              condition.description &&
+              typeof condition.description === 'object' &&
+              '$regex' in condition.description
+            ) {
+              const regex = new RegExp((condition.description as any).$regex, (condition.description as any).$options);
+              return item.description ? regex.test(item.description) : false;
+            }
+            return false;
+          });
+        });
+      }
+
+      const cursor = {
+        sort: vi.fn((sortSpec: Record<string, number>) => {
+          const sortKey = Object.keys(sortSpec)[0] as string | undefined;
+          if (!sortKey) {
+            return cursor;
+          }
+
+          const sortDir = sortSpec[sortKey] ?? -1;
+          if (sortKey === 'createdAt') {
+            items.sort((a, b) =>
+              sortDir === 1
+                ? a.createdAt.getTime() - b.createdAt.getTime()
+                : b.createdAt.getTime() - a.createdAt.getTime(),
+            );
+          } else if (sortKey === 'name') {
+            items.sort((a, b) =>
+              sortDir === 1 ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name),
+            );
+          } else if (sortKey === 'unitPrice') {
+            items.sort((a, b) =>
+              sortDir === 1 ? a.unitPrice - b.unitPrice : b.unitPrice - a.unitPrice,
+            );
+          }
+
+          return cursor;
+        }),
+        skip: vi.fn((count: number) => {
+          items = items.slice(count);
+          return cursor;
+        }),
+        limit: vi.fn((count: number) => {
+          items = items.slice(0, count);
+          return cursor;
+        }),
+        toArray: vi.fn(() => Promise.resolve(items)),
+      };
+
+      return cursor;
+    }),
+    countDocuments: vi.fn((filter: Record<string, unknown>) => {
+      let items = Array.from(records.values());
+
+      if (filter.profileId) {
+        items = items.filter((item) => item.profileId === filter.profileId);
+      }
+
+      if (filter.type) {
+        items = items.filter((item) => item.type === filter.type);
+      }
+
+      if (filter.$or) {
+        const orConditions = filter.$or as Array<Record<string, unknown>>;
+        items = items.filter((item) => {
+          return orConditions.some((condition) => {
+            if (condition.name && typeof condition.name === 'object' && '$regex' in condition.name) {
+              const regex = new RegExp((condition.name as any).$regex, (condition.name as any).$options);
+              return regex.test(item.name);
+            }
+            if (
+              condition.description &&
+              typeof condition.description === 'object' &&
+              '$regex' in condition.description
+            ) {
+              const regex = new RegExp((condition.description as any).$regex, (condition.description as any).$options);
+              return item.description ? regex.test(item.description) : false;
+            }
+            return false;
+          });
+        });
+      }
+
+      return Promise.resolve(items.length);
+    }),
+    db: {
+      collection: vi.fn((name: string) => {
+        if (name === 'orders') {
+          return {
+            findOne: vi.fn(() => Promise.resolve(null)),
+          };
+        }
+        return catalogCollection;
+      }),
+    },
+  };
+
+  const db = {
+    collection: vi.fn((name: string) => {
+      if (name === 'catalog') {
+        return catalogCollection;
+      }
+      throw new Error(`Unknown collection: ${name}`);
+    }),
+  } as unknown as Db;
+
+  return {
+    db,
+    records,
+    getCreateIndexCalls: () => createIndexCalls,
+  };
+};
+
+const buildTestApp = async (options?: {
+  authService?: AuthService;
+  profileStore?: ProfileStore;
+  catalogStore?: CatalogStore;
+  fakeDb?: ReturnType<typeof createFakeCatalogDb>;
+  envData?: Record<string, unknown>;
+}): Promise<FastifyInstance> => {
+  const authService = options?.authService ?? createAuthServiceMock();
+  const profileStore = options?.profileStore ?? createProfileStoreMock();
+  const fakeDb = options?.fakeDb ?? createFakeCatalogDb();
+  const catalogStore = options?.catalogStore ?? createCatalogStore(() => fakeDb.db);
+
+  return buildApp({
+    envData: {
+      ...DEFAULT_ENV,
+      ...(options?.envData ?? {}),
+    },
+    mongo: createMongoMock(true),
+    auth: authService,
+    profileStore,
+    catalogStore,
+  });
+};
+
+let app: FastifyInstance | undefined;
+
+afterEach(async () => {
+  if (!app) {
+    return;
+  }
+
+  await app.close();
+  app = undefined;
+});
+
+// ===== STORE TESTS =====
+describe('catalog store', () => {
+  it('should create profileId index', async () => {
+    const createIndexMock = vi.fn().mockResolvedValue('index_created');
+    const collectionMock = { createIndex: createIndexMock };
+    const dbMock = { collection: vi.fn(() => collectionMock) } as unknown as Db;
+    const store = createCatalogStore(() => dbMock);
+
+    await store.ensureIndexes();
+
+    expect(createIndexMock).toHaveBeenCalledWith(
+      { profileId: 1 },
+      { name: 'catalog_profileId' },
+    );
+  });
+
+  it('should create profileId and type index', async () => {
+    const createIndexMock = vi.fn().mockResolvedValue('index_created');
+    const collectionMock = { createIndex: createIndexMock };
+    const dbMock = { collection: vi.fn(() => collectionMock) } as unknown as Db;
+    const store = createCatalogStore(() => dbMock);
+
+    await store.ensureIndexes();
+
+    expect(createIndexMock).toHaveBeenCalledWith(
+      { profileId: 1, type: 1 },
+      { name: 'catalog_profileId_type' },
+    );
+  });
+
+  it('should create profileId and name index', async () => {
+    const createIndexMock = vi.fn().mockResolvedValue('index_created');
+    const collectionMock = { createIndex: createIndexMock };
+    const dbMock = { collection: vi.fn(() => collectionMock) } as unknown as Db;
+    const store = createCatalogStore(() => dbMock);
+
+    await store.ensureIndexes();
+
+    expect(createIndexMock).toHaveBeenCalledWith(
+      { profileId: 1, name: 1 },
+      { name: 'catalog_profileId_name' },
+    );
+  });
+
+  it('should create indexes only once for the same db', async () => {
+    const fakeDb = createFakeCatalogDb();
+    const store = createCatalogStore(() => fakeDb.db);
+
+    await store.ensureIndexes();
+    const firstCount = fakeDb.getCreateIndexCalls();
+
+    await store.ensureIndexes();
+    const secondCount = fakeDb.getCreateIndexCalls();
+
+    expect(secondCount).toBe(firstCount);
+  });
+
+  it('should create indexes again for a different db instance', async () => {
+    const fakeDb1 = createFakeCatalogDb();
+    const fakeDb2 = createFakeCatalogDb();
+    let currentDb = fakeDb1;
+
+    const store = createCatalogStore(() => currentDb.db);
+
+    await store.ensureIndexes();
+    const firstDbIndexes = fakeDb1.getCreateIndexCalls();
+
+    currentDb = fakeDb2;
+    await store.ensureIndexes();
+    const secondDbIndexes = fakeDb2.getCreateIndexCalls();
+
+    expect(firstDbIndexes).toBeGreaterThan(0);
+    expect(secondDbIndexes).toBeGreaterThan(0);
+  });
+
+  it('should return catalog collection when getCollection is called', () => {
+    const fakeDb = createFakeCatalogDb();
+    const store = createCatalogStore(() => fakeDb.db);
+
+    const collection = store.getCollection();
+
+    expect(collection).toBeDefined();
+  });
+
+  it('should use injected getDb function when getting collection', () => {
+    const fakeDb = createFakeCatalogDb();
+    const getDbMock = vi.fn(() => fakeDb.db);
+    const store = createCatalogStore(getDbMock);
+
+    store.getCollection();
+
+    expect(getDbMock).toHaveBeenCalled();
+  });
+
+  it('should not create indexes as side effect of getCollection', () => {
+    const fakeDb = createFakeCatalogDb();
+    const store = createCatalogStore(() => fakeDb.db);
+
+    store.getCollection();
+
+    expect(fakeDb.getCreateIndexCalls()).toBe(0);
+  });
+});
+
+// ===== GET /api/catalog TESTS =====
+describe('catalog GET /api/catalog', () => {
+  it('should return 401 when session is missing', async () => {
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue(null),
+      }),
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({
+      error: 'Unauthorized',
+      message: 'Unauthorized',
+      statusCode: 401,
+    });
+  });
+
+  it('should return list with default pagination', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item1 = createCatalogItemFixture(profile._id.toHexString());
+    const item2 = createCatalogItemFixture(profile._id.toHexString());
+    fakeDb.records.set(item1._id.toHexString(), item1);
+    fakeDb.records.set(item2._id.toHexString(), item2);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.page).toBe(1);
+    expect(data.limit).toBe(20);
+    expect(data.total).toBe(2);
+    expect(data.data.length).toBe(2);
+  });
+
+  it('should apply pagination from query params', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const items = Array.from({ length: 25 }, (_, i) =>
+      createCatalogItemFixture(profile._id.toHexString(), { name: `Item ${i + 1}` }),
+    );
+    items.forEach((item) => fakeDb.records.set(item._id.toHexString(), item));
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/catalog?page=2&limit=10',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.page).toBe(2);
+    expect(data.limit).toBe(10);
+    expect(data.total).toBe(25);
+  });
+
+  it('should cap pagination to maximum values', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const items = Array.from({ length: 250 }, (_, i) =>
+      createCatalogItemFixture(profile._id.toHexString(), { name: `Item ${i + 1}` }),
+    );
+    items.forEach((item) => fakeDb.records.set(item._id.toHexString(), item));
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/catalog?page=999999&limit=999999',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.page).toBe(1000);
+    expect(data.limit).toBe(100);
+    expect(data.total).toBe(250);
+    expect(data.data.length).toBe(0);
+  });
+
+  it('should filter by type when provided', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const product = createCatalogItemFixture(profile._id.toHexString(), { type: 'product' });
+    const service = createCatalogItemFixture(profile._id.toHexString(), { type: 'service' });
+    fakeDb.records.set(product._id.toHexString(), product);
+    fakeDb.records.set(service._id.toHexString(), service);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog?type=product' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.data.length).toBe(1);
+    expect(data.data[0].type).toBe('product');
+  });
+
+  it('should apply text search on name and description', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item1 = createCatalogItemFixture(profile._id.toHexString(), { name: 'Widget' });
+    const item2 = createCatalogItemFixture(profile._id.toHexString(), {
+      name: 'Gadget',
+      description: 'Contains widget',
+    });
+    fakeDb.records.set(item1._id.toHexString(), item1);
+    fakeDb.records.set(item2._id.toHexString(), item2);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog?q=widget' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.total).toBe(2);
+  });
+
+  it('should ignore empty search query', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item = createCatalogItemFixture(profile._id.toHexString());
+    fakeDb.records.set(item._id.toHexString(), item);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog?q=   ' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.total).toBe(1);
+  });
+
+  it('should sort by createdAt descending by default', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item1 = createCatalogItemFixture(profile._id.toHexString(), {
+      createdAt: new Date('2026-01-01T10:00:00.000Z'),
+    });
+    const item2 = createCatalogItemFixture(profile._id.toHexString(), {
+      createdAt: new Date('2026-01-02T10:00:00.000Z'),
+    });
+    fakeDb.records.set(item1._id.toHexString(), item1);
+    fakeDb.records.set(item2._id.toHexString(), item2);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.data[0].createdAt).toBe(item2.createdAt.toISOString());
+  });
+
+  it('should return only items from authenticated user profile', async () => {
+    const profile1 = createProfileFixture('auth-user-1');
+    const profile2 = createProfileFixture('auth-user-2');
+    const fakeDb = createFakeCatalogDb();
+    const item1 = createCatalogItemFixture(profile1._id.toHexString());
+    const item2 = createCatalogItemFixture(profile2._id.toHexString());
+    fakeDb.records.set(item1._id.toHexString(), item1);
+    fakeDb.records.set(item2._id.toHexString(), item2);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile1),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.data.length).toBe(1);
+    expect(data.data[0].profileId).toBe(profile1._id.toHexString());
+  });
+
+  it('should convert ObjectId to string and dates to ISO string', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item = createCatalogItemFixture(profile._id.toHexString());
+    fakeDb.records.set(item._id.toHexString(), item);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(typeof data.data[0]._id).toBe('string');
+    expect(typeof data.data[0].createdAt).toBe('string');
+    expect(typeof data.data[0].updatedAt).toBe('string');
+  });
+
+  it('should include description and costPrice only when present', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const itemWithOptionals = createCatalogItemFixture(profile._id.toHexString(), {
+      description: 'Has description',
+      costPrice: 50.0,
+    });
+    const itemWithoutOptionals = createCatalogItemFixture(profile._id.toHexString());
+    fakeDb.records.set(itemWithOptionals._id.toHexString(), itemWithOptionals);
+    fakeDb.records.set(itemWithoutOptionals._id.toHexString(), itemWithoutOptionals);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/catalog' });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    const withOptionals = data.data.find((d: any) => d.description);
+    const withoutOptionals = data.data.find((d: any) => !d.description);
+    expect(withOptionals.description).toBe('Has description');
+    expect(withOptionals.costPrice).toBe(50.0);
+    expect(withoutOptionals.description).toBeUndefined();
+    expect(withoutOptionals.costPrice).toBeUndefined();
+  });
+});
+
+// ===== POST /api/catalog TESTS =====
+describe('catalog POST /api/catalog', () => {
+  it('should return 401 when session is missing', async () => {
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue(null),
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/catalog',
+      payload: {
+        type: 'product',
+        name: 'Test Product',
+        unitPrice: 99.99,
+        unitMeasure: 'unit',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should create catalog item with authenticated user profile', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/catalog',
+      payload: {
+        type: 'product',
+        name: 'New Product',
+        unitPrice: 99.99,
+        unitMeasure: 'unit',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const data = response.json();
+    expect(data.profileId).toBe(profile._id.toHexString());
+    expect(data.type).toBe('product');
+    expect(data.name).toBe('New Product');
+  });
+
+  it('should include optional fields when provided', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/catalog',
+      payload: {
+        type: 'product',
+        name: 'Test Product',
+        unitPrice: 99.99,
+        unitMeasure: 'unit',
+        description: 'Test description',
+        costPrice: 50.0,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const data = response.json();
+    expect(data.description).toBe('Test description');
+    expect(data.costPrice).toBe(50.0);
+  });
+
+  it('should omit optional fields when not provided', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/catalog',
+      payload: {
+        type: 'product',
+        name: 'Test Product',
+        unitPrice: 99.99,
+        unitMeasure: 'unit',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const data = response.json();
+    expect(data.description).toBeUndefined();
+    expect(data.costPrice).toBeUndefined();
+  });
+
+  it('should reject invalid type', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/catalog',
+      payload: {
+        type: 'invalid',
+        name: 'Test Product',
+        unitPrice: 99.99,
+        unitMeasure: 'unit',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should reject negative unitPrice', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/catalog',
+      payload: {
+        type: 'product',
+        name: 'Test Product',
+        unitPrice: -10,
+        unitMeasure: 'unit',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should reject invalid unitMeasure', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/catalog',
+      payload: {
+        type: 'product',
+        name: 'Test Product',
+        unitPrice: 99.99,
+        unitMeasure: 'invalid_measure',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});
+
+// ===== PUT /api/catalog/:itemId TESTS =====
+describe('catalog PUT /api/catalog/:itemId', () => {
+  it('should return 401 when session is missing', async () => {
+    const itemId = new ObjectId().toHexString();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue(null),
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/catalog/${itemId}`,
+      payload: {
+        name: 'Updated Name',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should return 404 when item not found for profile', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const itemId = new ObjectId().toHexString();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/catalog/${itemId}`,
+      payload: {
+        name: 'Updated Name',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should update only provided fields', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item = createCatalogItemFixture(profile._id.toHexString(), {
+      name: 'Original Name',
+      description: 'Original Description',
+    });
+    fakeDb.records.set(item._id.toHexString(), item);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/catalog/${item._id.toHexString()}`,
+      payload: {
+        name: 'Updated Name',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const data = response.json();
+    expect(data.name).toBe('Updated Name');
+    expect(data.description).toBe('Original Description');
+  });
+
+  it('should reject empty body', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item = createCatalogItemFixture(profile._id.toHexString());
+    fakeDb.records.set(item._id.toHexString(), item);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/catalog/${item._id.toHexString()}`,
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should reject invalid itemId format', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      catalogStore: createCatalogStore(() => fakeDb.db),
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/catalog/invalid-id',
+      payload: {
+        name: 'Updated Name',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});
+
+// ===== DELETE /api/catalog/:itemId TESTS =====
+describe('catalog DELETE /api/catalog/:itemId', () => {
+  it('should return 401 when session is missing', async () => {
+    const itemId = new ObjectId().toHexString();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue(null),
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/api/catalog/${itemId}`,
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should return 404 when item not found', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const itemId = new ObjectId().toHexString();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/api/catalog/${itemId}`,
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should return 204 when item is deleted successfully', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+    const item = createCatalogItemFixture(profile._id.toHexString());
+    fakeDb.records.set(item._id.toHexString(), item);
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      fakeDb,
+    });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/api/catalog/${item._id.toHexString()}`,
+    });
+
+    expect(response.statusCode).toBe(204);
+  });
+
+  it('should reject invalid itemId format', async () => {
+    const profile = createProfileFixture('auth-user-1');
+    const fakeDb = createFakeCatalogDb();
+
+    app = await buildTestApp({
+      authService: createAuthServiceMock({
+        getSessionFromHeaders: vi.fn().mockResolvedValue({ user: { id: 'auth-user-1', email: 'test@example.com' } }),
+      }),
+      profileStore: createProfileStoreMock(profile),
+      catalogStore: createCatalogStore(() => fakeDb.db),
+    });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/catalog/invalid-id',
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/src/apps/api/src/routes/catalog.ts
+++ b/src/apps/api/src/routes/catalog.ts
@@ -101,10 +101,21 @@ const CatalogSortBySchema = Type.Union([
 
 const CatalogSortOrderSchema = Type.Union([Type.Literal('asc'), Type.Literal('desc')]);
 
+const PAGE_DEFAULT = 1;
+const LIMIT_DEFAULT = 20;
+const MAX_PAGE = 1000;
+const MAX_LIMIT = 100;
+const POSITIVE_INTEGER_PATTERN = '^[1-9][0-9]*$';
+const POSITIVE_INTEGER_REGEX = new RegExp(POSITIVE_INTEGER_PATTERN);
+
+const PositiveIntegerStringSchema = Type.String({ pattern: POSITIVE_INTEGER_PATTERN });
+
 const CatalogListQuerySchema = Type.Object(
   {
-    page: Type.Optional(Type.Integer({ minimum: 1 })),
-    limit: Type.Optional(Type.Integer({ minimum: 1 })),
+    page: Type.Optional(Type.Union([Type.Integer({ minimum: 1, maximum: MAX_PAGE }), PositiveIntegerStringSchema])),
+    limit: Type.Optional(
+      Type.Union([Type.Integer({ minimum: 1, maximum: MAX_LIMIT }), PositiveIntegerStringSchema]),
+    ),
     q: Type.Optional(Type.String()),
     type: Type.Optional(CatalogTypeSchema),
     sortBy: Type.Optional(CatalogSortBySchema),
@@ -186,6 +197,37 @@ type CatalogUpdateBody = Static<typeof CatalogUpdateSchema>;
 type CatalogParams = Static<typeof CatalogParamsSchema>;
 type CatalogListQuery = Static<typeof CatalogListQuerySchema>;
 
+const toBoundedPositiveInteger = (
+  value: number | string | undefined,
+  fallback: number,
+  maximum: number,
+): number => {
+  const safeFallback = Math.min(Math.max(fallback, 1), maximum);
+
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      return safeFallback;
+    }
+
+    return Math.min(value, maximum);
+  }
+
+  if (typeof value === 'string') {
+    if (!POSITIVE_INTEGER_REGEX.test(value)) {
+      return safeFallback;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isSafeInteger(parsed) || parsed < 1) {
+      return safeFallback;
+    }
+
+    return Math.min(parsed, maximum);
+  }
+
+  return safeFallback;
+};
+
 const toCatalogResponse = (item: WithId<CatalogItem>): CatalogResponse => ({
   _id: item._id.toHexString(),
   profileId: item.profileId,
@@ -224,8 +266,8 @@ export const registerCatalogRoutes = (
       const profile = await dependencies.profileStore.ensureByAuthUserId(session.user.id);
       const query = request.query as CatalogListQuery;
 
-      const page = query.page ?? 1;
-      const limit = query.limit ?? 20;
+      const page = toBoundedPositiveInteger(query.page, PAGE_DEFAULT, MAX_PAGE);
+      const limit = toBoundedPositiveInteger(query.limit, LIMIT_DEFAULT, MAX_LIMIT);
       const sortBy = query.sortBy ?? 'createdAt';
       const sortOrder = query.sortOrder ?? 'desc';
       const skip = (page - 1) * limit;


### PR DESCRIPTION
This pull request updates the documentation and implementation for backend unit testing and improves the pagination logic in the catalog API. The documentation is revised to reflect the use of Node.js, pnpm, and Vitest instead of .NET, and provides detailed coverage information for catalog tests. In the code, pagination parameters are now more robustly validated, supporting both numeric and string values, with enforced upper bounds.

**Documentation updates:**

* The unit testing documentation (`docs/08-Registro de Testes Unitários.md`) is rewritten to describe the Node.js, pnpm, and Vitest setup, replacing the previous .NET/xUnit instructions. It also includes detailed coverage notes for the catalog API tests, describing endpoints, behaviors, and testing strategies.

**API pagination improvements:**

* The catalog API's pagination parameters (`page` and `limit`) now accept both integers and positive integer strings, with strict validation using a regular expression and enforced maximum values (`MAX_PAGE`, `MAX_LIMIT`).
* A utility function `toBoundedPositiveInteger` is introduced to safely parse and bound pagination parameters from query strings, ensuring fallback to defaults and prevention of invalid or excessive values.
* The catalog route handler is updated to use the new parsing and bounding logic for `page` and `limit`, ensuring consistent and safe pagination behavior.